### PR TITLE
🚫 No Caching Policy

### DIFF
--- a/Tensai.xcodeproj/project.pbxproj
+++ b/Tensai.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		307695A0254367410028E1E7 /* ViewRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3076959F254367410028E1E7 /* ViewRouter.swift */; };
 		307695A525439DD30028E1E7 /* HBarPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307695A425439DD30028E1E7 /* HBarPicker.swift */; };
 		30A04E372553BC54009C9695 /* TriviaQuizCreatorFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E362553BC54009C9695 /* TriviaQuizCreatorFormTests.swift */; };
-		30A04E472556153C009C9695 /* Question.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E462556153C009C9695 /* Question.swift */; };
+		30A04E472556153C009C9695 /* OTDQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E462556153C009C9695 /* OTDQuestion.swift */; };
 		30A04E4E25573717009C9695 /* OpenTriviaDatabaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E4D25573717009C9695 /* OpenTriviaDatabaseResponse.swift */; };
 		30E757BE257B061200CC1F53 /* NoCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E757BD257B061200CC1F53 /* NoCaching.swift */; };
 		30F078DC253E49F600D7A912 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 30F078DB253E49F600D7A912 /* LaunchScreen.storyboard */; };
@@ -62,7 +62,7 @@
 		30A04E342553BC54009C9695 /* TensaiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TensaiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		30A04E362553BC54009C9695 /* TriviaQuizCreatorFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriviaQuizCreatorFormTests.swift; sourceTree = "<group>"; };
 		30A04E382553BC54009C9695 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		30A04E462556153C009C9695 /* Question.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Question.swift; sourceTree = "<group>"; };
+		30A04E462556153C009C9695 /* OTDQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTDQuestion.swift; sourceTree = "<group>"; };
 		30A04E4D25573717009C9695 /* OpenTriviaDatabaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTriviaDatabaseResponse.swift; sourceTree = "<group>"; };
 		30E757BD257B061200CC1F53 /* NoCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoCaching.swift; sourceTree = "<group>"; };
 		30F078DB253E49F600D7A912 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -196,7 +196,7 @@
 		30A04E4525561457009C9695 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				30A04E462556153C009C9695 /* Question.swift */,
+				30A04E462556153C009C9695 /* OTDQuestion.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -325,7 +325,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				301F0ACE253A60A8000C6439 /* TensaiApp.swift in Sources */,
-				30A04E472556153C009C9695 /* Question.swift in Sources */,
+				30A04E472556153C009C9695 /* OTDQuestion.swift in Sources */,
 				307695A0254367410028E1E7 /* ViewRouter.swift in Sources */,
 				306E7543254E2AE9004145A6 /* TriviaQuizCreatorForm.swift in Sources */,
 				307695A525439DD30028E1E7 /* HBarPicker.swift in Sources */,

--- a/Tensai.xcodeproj/project.pbxproj
+++ b/Tensai.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		30A04E372553BC54009C9695 /* TriviaQuizCreatorFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E362553BC54009C9695 /* TriviaQuizCreatorFormTests.swift */; };
 		30A04E472556153C009C9695 /* Question.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E462556153C009C9695 /* Question.swift */; };
 		30A04E4E25573717009C9695 /* OpenTriviaDatabaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E4D25573717009C9695 /* OpenTriviaDatabaseResponse.swift */; };
+		30E757BE257B061200CC1F53 /* NoCaching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E757BD257B061200CC1F53 /* NoCaching.swift */; };
 		30F078DC253E49F600D7A912 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 30F078DB253E49F600D7A912 /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
@@ -63,6 +64,7 @@
 		30A04E382553BC54009C9695 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		30A04E462556153C009C9695 /* Question.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Question.swift; sourceTree = "<group>"; };
 		30A04E4D25573717009C9695 /* OpenTriviaDatabaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenTriviaDatabaseResponse.swift; sourceTree = "<group>"; };
+		30E757BD257B061200CC1F53 /* NoCaching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoCaching.swift; sourceTree = "<group>"; };
 		30F078DB253E49F600D7A912 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -204,6 +206,7 @@
 			children = (
 				3013E1E6255FB49F00C2B2FB /* APIRequest.swift */,
 				3013E1EA255FBA6600C2B2FB /* APIRequestLoader.swift */,
+				30E757BD257B061200CC1F53 /* NoCaching.swift */,
 				30A04E4D25573717009C9695 /* OpenTriviaDatabaseResponse.swift */,
 				3013E1EE2560E33200C2B2FB /* TriviaQuizRequest.swift */,
 			);
@@ -329,6 +332,7 @@
 				301F0AD0253A60A8000C6439 /* RootView.swift in Sources */,
 				304598CA256A312200635005 /* TriviaQuizCreatorView.swift in Sources */,
 				30A04E4E25573717009C9695 /* OpenTriviaDatabaseResponse.swift in Sources */,
+				30E757BE257B061200CC1F53 /* NoCaching.swift in Sources */,
 				3013E1E7255FB49F00C2B2FB /* APIRequest.swift in Sources */,
 				3013E1EB255FBA6600C2B2FB /* APIRequestLoader.swift in Sources */,
 				3013E1EF2560E33200C2B2FB /* TriviaQuizRequest.swift in Sources */,

--- a/Tensai/Models/OTDQuestion.swift
+++ b/Tensai/Models/OTDQuestion.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A question in the *Open Trivia Database*.
-struct Question: Codable {
+struct OTDQuestion: Codable {
     
     // -------------------------------------------------------------------------
     // MARK:- Stored properties

--- a/Tensai/Networking/APIRequestLoader.swift
+++ b/Tensai/Networking/APIRequestLoader.swift
@@ -12,8 +12,12 @@ struct APIRequestLoader<T> where T: APIRequest {
     /// Creates a loader with the specified API request and URL session.
     ///
     /// - Parameter apiRequest: The API request.
-    /// - Parameter urlSession: The URL session. The default is `.shared`.
-    init(apiRequest: T, urlSession: URLSession = .shared) {
+    /// - Parameter urlSession: The URL session. The default is a session that
+    ///                         is configured with no caching policy.
+    init(
+        apiRequest: T,
+        urlSession: URLSession = URLSession(configuration: .noCaching)
+    ) {
         self.apiRequest = apiRequest
         self.urlSession = urlSession
     }

--- a/Tensai/Networking/NoCaching.swift
+++ b/Tensai/Networking/NoCaching.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension URLSessionConfiguration {
+    
+    /// A session configuration that has no caching policy.
+    static var noCaching: URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.default
+        configuration.urlCache = nil
+        return configuration
+    }
+}

--- a/Tensai/Networking/OpenTriviaDatabaseResponse.swift
+++ b/Tensai/Networking/OpenTriviaDatabaseResponse.swift
@@ -7,7 +7,7 @@ struct OpenTriviaDatabaseResponse: Codable {
     let code: Int
     
     /// The questions.
-    let questions: [Question]
+    let questions: [OTDQuestion]
     
     /// An internal type that contains the keys for encoding and decoding.
     private enum CodingKeys: String, CodingKey {

--- a/TensaiTests/Networking Tests/APILoaderTests.swift
+++ b/TensaiTests/Networking Tests/APILoaderTests.swift
@@ -6,7 +6,7 @@ final class APILoaderTests: XCTestCase {
     private var loader: APIRequestLoader<TriviaQuizRequest>!
     
     override func setUp() {
-        let configuration = URLSessionConfiguration.ephemeral
+        let configuration = URLSessionConfiguration.noCaching
         configuration.protocolClasses = [MockURLProtocol.self]
         loader = APIRequestLoader<TriviaQuizRequest>(
             apiRequest: TriviaQuizRequest(),


### PR DESCRIPTION
From [**Secure Code Warrior**](https://www.securecodewarrior.com) training:

> **Vulnerability:** `URLRequest` responses are cached by default. This is insecure behavior that should be disabled for all requests. This could result in leakage of sensitive information.
> 
> **Solution:** There should be no caching policy at all. This way, no possibly sensitive information remains kept on the device.