### PR TITLE
View Model Renaming

### DIFF
--- a/Tensai.xcodeproj/project.pbxproj
+++ b/Tensai.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		307695A0254367410028E1E7 /* ViewRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3076959F254367410028E1E7 /* ViewRouter.swift */; };
 		307695A525439DD30028E1E7 /* HBarPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307695A425439DD30028E1E7 /* HBarPicker.swift */; };
 		308D521B258977560021A735 /* TriviaQuizTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308D521A258977560021A735 /* TriviaQuizTests.swift */; };
-		308D5221258986630021A735 /* TriviaQuizRound.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308D5220258986630021A735 /* TriviaQuizRound.swift */; };
+		308D5221258986630021A735 /* TriviaQuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308D5220258986630021A735 /* TriviaQuizViewModel.swift */; };
 		308D5227258991910021A735 /* TriviaQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 308D5226258991910021A735 /* TriviaQuizView.swift */; };
 		30A04E372553BC54009C9695 /* TriviaQuizConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E362553BC54009C9695 /* TriviaQuizConfigTests.swift */; };
 		30A04E472556153C009C9695 /* OTDQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A04E462556153C009C9695 /* OTDQuestion.swift */; };
@@ -80,7 +80,7 @@
 		3076959F254367410028E1E7 /* ViewRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewRouter.swift; sourceTree = "<group>"; };
 		307695A425439DD30028E1E7 /* HBarPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HBarPicker.swift; sourceTree = "<group>"; };
 		308D521A258977560021A735 /* TriviaQuizTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriviaQuizTests.swift; sourceTree = "<group>"; };
-		308D5220258986630021A735 /* TriviaQuizRound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriviaQuizRound.swift; sourceTree = "<group>"; };
+		308D5220258986630021A735 /* TriviaQuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriviaQuizViewModel.swift; sourceTree = "<group>"; };
 		308D5226258991910021A735 /* TriviaQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriviaQuizView.swift; sourceTree = "<group>"; };
 		308D524D258C2D8B0021A735 /* trivia_quiz.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = trivia_quiz.png; sourceTree = "<group>"; };
 		30A04E342553BC54009C9695 /* TensaiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TensaiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -206,7 +206,7 @@
 		3076959E254366DA0028E1E7 /* View Models */ = {
 			isa = PBXGroup;
 			children = (
-				308D5220258986630021A735 /* TriviaQuizRound.swift */,
+				308D5220258986630021A735 /* TriviaQuizViewModel.swift */,
 			);
 			path = "View Models";
 			sourceTree = "<group>";
@@ -379,7 +379,7 @@
 				303E5949259D2EFC00B65183 /* ErrorAlert.swift in Sources */,
 				30A04E472556153C009C9695 /* OTDQuestion.swift in Sources */,
 				30168BF42580732900FB65B9 /* TriviaQuiz.swift in Sources */,
-				308D5221258986630021A735 /* TriviaQuizRound.swift in Sources */,
+				308D5221258986630021A735 /* TriviaQuizViewModel.swift in Sources */,
 				30595DCC25A2B2C400456E16 /* CapsuleButton.swift in Sources */,
 				307695A525439DD30028E1E7 /* HBarPicker.swift in Sources */,
 				30372837259C02F800A866D4 /* LoadingView.swift in Sources */,

--- a/Tensai/View Models/TriviaQuizViewModel.swift
+++ b/Tensai/View Models/TriviaQuizViewModel.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-/// A round with a quiz of trivia questions.
-final class TriviaQuizRound: ObservableObject {
+/// A view model that binds a view to a quiz of trivia questions.
+final class TriviaQuizViewModel: ObservableObject {
     
     // -------------------------------------------------------------------------
     // MARK:- Model

--- a/Tensai/ViewRouter.swift
+++ b/Tensai/ViewRouter.swift
@@ -15,10 +15,10 @@ final class ViewRouter: ObservableObject {
         
         /// The key to render a view where the user answers questions in a
         /// trivia quiz.
-        case triviaQuiz(TriviaQuizRound)
+        case triviaQuiz(TriviaQuizViewModel)
         
         /// The key to render a view where the user can see the result of a
         /// trivia quiz.
-        case triviaQuizResult(TriviaQuizRound)
+        case triviaQuizResult(TriviaQuizViewModel)
     }
 }

--- a/Tensai/Views/RootView.swift
+++ b/Tensai/Views/RootView.swift
@@ -10,11 +10,11 @@ struct RootView: View {
         switch viewRouter.currentViewKey {
         case .triviaQuizConfig:
             TriviaQuizConfigView()
-        case .triviaQuiz(let round):
-            TriviaQuizView(triviaQuizRound: round)
+        case .triviaQuiz(let viewModel):
+            TriviaQuizView(viewModel: viewModel)
                 .transition(.move(edge: .trailing))
-        case .triviaQuizResult(let round):
-            TriviaQuizResultView(triviaQuizRound: round)
+        case .triviaQuizResult(let viewModel):
+            TriviaQuizResultView(viewModel: viewModel)
                 .transition(.move(edge: .trailing))
         }
     }

--- a/Tensai/Views/TriviaQuizConfigView.swift
+++ b/Tensai/Views/TriviaQuizConfigView.swift
@@ -140,7 +140,7 @@ struct TriviaQuizConfigView: View {
                     )
                     withAnimation {
                         self.viewRouter.currentViewKey = .triviaQuiz(
-                            TriviaQuizRound(triviaQuiz: triviaQuiz)
+                            TriviaQuizViewModel(triviaQuiz: triviaQuiz)
                         )
                     }
                 }

--- a/Tensai/Views/TriviaQuizResultView.swift
+++ b/Tensai/Views/TriviaQuizResultView.swift
@@ -7,8 +7,8 @@ struct TriviaQuizResultView: View {
     // MARK:- State management
     // -------------------------------------------------------------------------
     
-    /// The round with a quiz of trivia questions.
-    @ObservedObject var triviaQuizRound: TriviaQuizRound
+    /// The view model that binds this view to a quiz of trivia questions.
+    @ObservedObject var viewModel: TriviaQuizViewModel
     
     /// The view router.
     @EnvironmentObject private var viewRouter: ViewRouter
@@ -40,8 +40,8 @@ struct TriviaQuizResultView: View {
     )
     
     var body: some View {
-        let correctAnswerCount = triviaQuizRound.correctAnswerCount
-        let questionCount = triviaQuizRound.questions.count
+        let correctAnswerCount = viewModel.correctAnswerCount
+        let questionCount = viewModel.questions.count
         
         return ZStack {
             VStack(spacing: 12) {
@@ -55,7 +55,7 @@ struct TriviaQuizResultView: View {
                 Text("\(correctAnswerCount)/\(questionCount)")
                     .font(.system(size: 64, weight: .heavy))
                     .foregroundColor(scoreColor)
-                Text("Score: \(triviaQuizRound.score)")
+                Text("Score: \(viewModel.score)")
                     .font(.title2)
                     .fontWeight(.medium)
                 Spacer()
@@ -70,9 +70,7 @@ struct TriviaQuizResultView: View {
                 }
                 CapsuleButton(title: "Review Questions", action: reviewQuiz)
                     .fullScreenCover(isPresented: $questionsArePresented) {
-                        TriviaQuizReviewView(
-                            questions: triviaQuizRound.questions
-                        )
+                        TriviaQuizReviewView(questions: viewModel.questions)
                     }
                 CapsuleButton(title: "Start a New Quiz", action: goToConfigView)
             }
@@ -86,8 +84,8 @@ struct TriviaQuizResultView: View {
     
     /// Indicates whether the player passed the trivia quiz.
     private var playerPassed: Bool {
-        let correctAnswerCount = Double(triviaQuizRound.correctAnswerCount)
-        let questionCount = Double(triviaQuizRound.questions.count)
+        let correctAnswerCount = Double(viewModel.correctAnswerCount)
+        let questionCount = Double(viewModel.questions.count)
         return correctAnswerCount / questionCount >= passingThreshold
     }
     
@@ -188,7 +186,7 @@ struct TriviaQuizResultView: View {
                     )
                     withAnimation {
                         self.viewRouter.currentViewKey = .triviaQuiz(
-                            TriviaQuizRound(triviaQuiz: triviaQuiz)
+                            TriviaQuizViewModel(triviaQuiz: triviaQuiz)
                         )
                     }
                 }
@@ -210,7 +208,7 @@ struct TriviaQuizResultView: View {
 struct TriviaQuizResultView_Previews: PreviewProvider {
     static var previews: some View {
         let view = TriviaQuizResultView(
-            triviaQuizRound: TriviaQuizRound(
+            viewModel: TriviaQuizViewModel(
                 triviaQuiz: TriviaQuiz(
                     questions: [
                         OTDQuestion(

--- a/Tensai/Views/TriviaQuizView.swift
+++ b/Tensai/Views/TriviaQuizView.swift
@@ -7,8 +7,8 @@ struct TriviaQuizView: View {
     // MARK:- State management
     // -------------------------------------------------------------------------
     
-    /// The round with a quiz of trivia questions.
-    @ObservedObject var triviaQuizRound: TriviaQuizRound
+    /// The view model that binds this view to a quiz of trivia questions.
+    @ObservedObject var viewModel: TriviaQuizViewModel
     
     /// The view router.
     @EnvironmentObject private var viewRouter: ViewRouter
@@ -25,10 +25,10 @@ struct TriviaQuizView: View {
     
     var body: some View {
         let questionNumber = currentQuestionIndex + 1
-        let questionCount = triviaQuizRound.questions.count
+        let questionCount = viewModel.questions.count
         
         return VStack(alignment: .leading, spacing: 6) {
-            Text("Score: \(triviaQuizRound.score)")
+            Text("Score: \(viewModel.score)")
                 .font(.title)
                 .fontWeight(.medium)
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -57,7 +57,7 @@ struct TriviaQuizView: View {
     
     /// The current question.
     private var currentQuestion: TriviaQuiz.Question {
-        triviaQuizRound.questions[currentQuestionIndex]
+        viewModel.questions[currentQuestionIndex]
     }
     
     /// The horizontal star meter that represents the difficulty level of the
@@ -172,14 +172,12 @@ struct TriviaQuizView: View {
     ///
     /// - Parameter answer: The player’s answer to the current question.
     private func selectAnswer(_ answer: String) {
-        triviaQuizRound.submitAnswer(answer, at: currentQuestionIndex)
+        viewModel.submitAnswer(answer, at: currentQuestionIndex)
         DispatchQueue.main.asyncAfter(deadline: .now() + delayForNextQuestion) {
             let questionNumber = currentQuestionIndex + 1
-            let questionCount = triviaQuizRound.questions.count
+            let questionCount = viewModel.questions.count
             if questionNumber == questionCount {
-                self.viewRouter.currentViewKey = .triviaQuizResult(
-                    triviaQuizRound
-                )
+                self.viewRouter.currentViewKey = .triviaQuizResult(viewModel)
                 return
             }
             currentQuestionIndex += 1
@@ -208,7 +206,7 @@ struct TriviaQuizView: View {
 struct TriviaQuizView_Previews: PreviewProvider {
     static var previews: some View {
         let view = TriviaQuizView(
-            triviaQuizRound: TriviaQuizRound(
+            viewModel: TriviaQuizViewModel(
                 triviaQuiz: TriviaQuiz(
                     questions: [
                         OTDQuestion(


### PR DESCRIPTION
Renamed the `TriviaQuizRound` view model class to `TriviaQuizViewModel`.

-----

According to an email from John Sundell:

> I think the name of a given view model should match the view that it’s being connected to. So if the view is called `CalculatorView`, then I name its view model `CalculatorViewModel`.