### PR TITLE
Typography Modifications

### DIFF
--- a/Tensai/Themes/Trebek.swift
+++ b/Tensai/Themes/Trebek.swift
@@ -23,8 +23,7 @@ extension UrbanTheme {
             dark: Color(red: 0.0431, green: 0.1176, blue: 0.2353)
         )
         
-        theme.typography.buttonTypeface = "Barlow Condensed Medium"
-        theme.typography.buttonFontSize = 16
+        theme.typography.button = .custom("Barlow Condensed Medium", size: 28)
         
         return theme
     }()

--- a/Tensai/Urban/Modifiers/UrbanButtonStyle.swift
+++ b/Tensai/Urban/Modifiers/UrbanButtonStyle.swift
@@ -79,7 +79,7 @@ struct UrbanButtonStyle: ButtonStyle {
         
         var body: some View {
             configuration.label
-                .font(contentFont)
+                .font(theme.typography.button)
                 .textCase(.uppercase)
                 .multilineTextAlignment(.center)
                 .foregroundColor(foregroundColor)
@@ -127,17 +127,6 @@ struct UrbanButtonStyle: ButtonStyle {
                     )
                 }
             }
-        }
-        
-        /// The font of the button’s content.
-        private var contentFont: Font {
-            let fontSize = theme.typography.buttonFontSize
-            
-            if let buttonTypeface = theme.typography.buttonTypeface {
-                return .custom(buttonTypeface, fixedSize: fontSize)
-            }
-            
-            return .system(size: fontSize)
         }
         
         /// The main/content color pair when the button is enabled.

--- a/Tensai/Urban/Modifiers/UrbanButtonStyle.swift
+++ b/Tensai/Urban/Modifiers/UrbanButtonStyle.swift
@@ -121,10 +121,7 @@ struct UrbanButtonStyle: ButtonStyle {
             
             return Group {
                 if variant == .outlined {
-                    shape.stroke(
-                        borderColor,
-                        lineWidth: Constants.outlinedButtonBorderWidth
-                    )
+                    shape.stroke(borderColor, lineWidth: Constants.borderWidth)
                 }
             }
         }
@@ -174,10 +171,10 @@ struct UrbanButtonStyle: ButtonStyle {
         }
     }
     
-    /// An internal struct that contains drawing constants.
-    private struct Constants {
+    /// An internal enum that contains drawing constants.
+    private enum Constants {
+        static let borderWidth: CGFloat = 2
         static let highlightOpacity: Double = 0.25
-        static let outlinedButtonBorderWidth: CGFloat = 2
         static let verticalPadding: CGFloat = 8
     }
 }

--- a/Tensai/Urban/Modifiers/UrbanButtonStyle.swift
+++ b/Tensai/Urban/Modifiers/UrbanButtonStyle.swift
@@ -216,14 +216,10 @@ struct UrbanButtonStyle_Previews: PreviewProvider {
             VStack(spacing: 16) {
                 ForEach(variants, id: \.self) { variant in
                     ForEach(colors, id: \.self) { color in
-                        Button(action: {}) {
-                            Text("Press Me").fontWeight(.semibold)
-                        }
+                        Button("Press Me") {}
                             .buttonStyle(.urban(variant: variant, color: color))
                     }
-                    Button(action: {}) {
-                        Text("Press Me").fontWeight(.semibold)
-                    }
+                    Button("Press Me") {}
                         .buttonStyle(.urban(variant: variant))
                         .disabled(true)
                 }
@@ -237,16 +233,12 @@ struct UrbanButtonStyle_Previews: PreviewProvider {
                 ForEach(variants, id: \.self) { variant in
                     ForEach(colors, id: \.self) { color in
                         Button(action: {}) {
-                            Text("Press Me")
-                                .fontWeight(.semibold)
-                                .frame(maxWidth: 100)
+                            Text("Press Me").frame(maxWidth: 100)
                         }
                             .buttonStyle(.urban(variant: variant, color: color))
                     }
                     Button(action: {}) {
-                        Text("Press Me")
-                            .fontWeight(.semibold)
-                            .frame(maxWidth: 100)
+                        Text("Press Me").frame(maxWidth: 100)
                     }
                         .buttonStyle(.urban(variant: variant))
                         .disabled(true)

--- a/Tensai/Urban/Modifiers/View+UrbanPaper.swift
+++ b/Tensai/Urban/Modifiers/View+UrbanPaper.swift
@@ -98,9 +98,7 @@ struct UrbanPaper_Previews: PreviewProvider {
             }
                 .padding()
             Divider()
-            Button(action: {}) {
-                Text("Expand").fontWeight(.semibold)
-            }
+            Button("Expand") {}
                 .buttonStyle(.urban())
                 .padding(8)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Tensai/Urban/Modifiers/View+UrbanPaper.swift
+++ b/Tensai/Urban/Modifiers/View+UrbanPaper.swift
@@ -41,14 +41,17 @@ fileprivate struct UrbanPaper: ViewModifier {
             .background(theme.palette.surface.main)
             .clipShape(shape)
             .overlay(borderLayer)
-            .shadow(radius: hasShadow ? 4 : 0)
+            .shadow(radius: hasShadow ? Constants.shadowRadius : 0)
     }
     
     /// The border “layer” of the paper element.
     private var borderLayer: some View {
         Group {
             if hasBorder {
-                shape.stroke(theme.palette.surface.content, lineWidth: 2)
+                shape.stroke(
+                    theme.palette.surface.content,
+                    lineWidth: Constants.borderWidth
+                )
             }
         }
     }
@@ -56,6 +59,12 @@ fileprivate struct UrbanPaper: ViewModifier {
     /// The shape of the paper element.
     private var shape: some Shape {
         RoundedRectangle(cornerRadius: theme.cornerRadius)
+    }
+    
+    /// An internal enum that contains drawing constants.
+    private enum Constants {
+        static let borderWidth: CGFloat = 2
+        static let shadowRadius: CGFloat = 4
     }
 }
 

--- a/Tensai/Urban/UrbanTheme.swift
+++ b/Tensai/Urban/UrbanTheme.swift
@@ -42,8 +42,8 @@ struct UrbanTheme {
     /// The color palette.
     var palette = Palette()
     
-    /// The font settings.
-    var typography = Typography()
+    /// The font set.
+    var typography = FontSet()
     
     /// The standard corner radius of the components.
     var cornerRadius: CGFloat = 4
@@ -105,20 +105,15 @@ struct UrbanTheme {
         )
     }
     
-    /// A collection of font settings that present the app’s content as clearly
-    /// and efficiently as possible.
-    struct Typography {
+    /// A set of fonts that present the app’s content as clearly and efficiently
+    /// as possible.
+    struct FontSet {
         
-        /// Creates the default font settings.
+        /// Creates the default font set.
         init() {}
         
-        /// The typeface for button titles.
-        ///
-        /// If it is `nil`, then the system font will be used.
-        var buttonTypeface: String?
-        
-        /// The font size of a button’s title.
-        var buttonFontSize: CGFloat = 14
+        /// The font for button titles.
+        var button = Font.body.bold()
     }
 }
 

--- a/Tensai/Urban/UrbanTheme.swift
+++ b/Tensai/Urban/UrbanTheme.swift
@@ -112,6 +112,18 @@ struct UrbanTheme {
         /// Creates the default font set.
         init() {}
         
+        /// The title font.
+        var title = Font.largeTitle
+        
+        /// The header font.
+        var header = Font.title
+        
+        /// The subheader font.
+        var subheader = Font.title2
+        
+        /// The font for body text.
+        var body = Font.body
+        
         /// The font for button titles.
         var button = Font.body.bold()
     }


### PR DESCRIPTION
  * Renamed `UrbanTheme.Typography` to `UrbanTheme.FontSet`.
  * Consolidated `buttonTypeface` and `buttonFontSize` into `button`.
  * Added 4 predefined fonts in the theme’s typography: `title`, `header`, `subheader`, and `body`.